### PR TITLE
remove broken hyperlink for discord rendering

### DIFF
--- a/content.md
+++ b/content.md
@@ -1,6 +1,6 @@
 A collection of tools and resources to enhance your gameplay!
 
-This list is also available online at: [https://resources.osucord.moe/](https://resources.osucord.moe/)
+This list is also available online at: https://resources.osucord.moe/
 
 -# Is something missing? Contribute to this list on [GitHub](https://github.com/osucord/resources).
 ---


### PR DESCRIPTION
The website doesn't render this, only discord does, so we don't need to consider hyperlinking it correctly within the content.md.

This will fix discord's rendering.