### PR TITLE
Add osu! beatmap atlas to beatmap search tools

### DIFF
--- a/content.md
+++ b/content.md
@@ -56,7 +56,7 @@ This list is also available online at: https://resources.osucord.moe/
 - [osu!Collector](https://osucollector.com/) - Beatmap collections from the members of the osu! community
 - [OMDB](http://omdb.nyahh.net/descriptors/) - Beatmaps categorized by various descriptors such as gimmicks, styles, skillsets, and more
 - [osu!pps](https://osu-pps.com/#/osu/maps) - Website for finding common farm maps within your skill range
-- [osu! Beatmap Atlas](https://osu-atlas.ameo.dev/) - An embedding-based tool that groups similar beatmaps together in space
+- [osu! Beatmap Atlas](https://osu-atlas.ameo.dev/) - A map that groups similar beatmaps together in space
 ---
 ### Skins
 - [osuck](https://skins.osuck.net/) - Website to get skins for all game modes

--- a/content.md
+++ b/content.md
@@ -56,6 +56,7 @@ This list is also available online at: https://resources.osucord.moe/
 - [osu!Collector](https://osucollector.com/) - Beatmap collections from the members of the osu! community
 - [OMDB](http://omdb.nyahh.net/descriptors/) - Beatmaps categorized by various descriptors such as gimmicks, styles, skillsets, and more
 - [osu!pps](https://osu-pps.com/#/osu/maps) - Website for finding common farm maps within your skill range
+- [osu! Beatmap Atlas](https://osu-atlas.ameo.dev/) - An embedding-based tool that groups similar beatmaps together in space
 ---
 ### Skins
 - [osuck](https://skins.osuck.net/) - Website to get skins for all game modes


### PR DESCRIPTION
The [osu! beatmap atlas](https://osu-atlas.ameo.dev) is a little tool I built that uses an embedding visualization to place similar beatmaps near each other.  It's useful to visualize your own top plays in the context of the broader osu universe as well as to find new maps to farm.

I came across your really nicely organized site and thought it might be a nice inclusion.  If not no worries at all of course.

Feel free to re-word the description or anything else as well.

Thanks for putting together and maintaining this great reosurce!