### PR TITLE
add tablet area calc (#58)

### DIFF
--- a/content.md
+++ b/content.md
@@ -2,15 +2,23 @@ A collection of tools and resources to enhance your gameplay!
 
 This list is also available online at: https://resources.osucord.moe/
 
--# Is something missing? Contribute to this list on [GitHub](https://github.com/osucord/resources).
----
+## -# Is something missing? Contribute to this list on [GitHub](https://github.com/osucord/resources).
+
 ### Official links
-- [@osugame YouTube](https://www.youtube.com/@osugame) - The official osu! YouTube channel for game updates and staff interviews
-- [@osugame Twitter](https://x.com/osugame) - The official osu! Twitter account highlighting featured artists and official tournaments
-- [osu!wiki](https://osu.ppy.sh/wiki/en/Main_page) - Tons of different articles about osu!
-- [osu! tournaments](https://osu.ppy.sh/community/tournaments) - The listing of ongoing and past tournaments ran by the official game staff
-- [osu! Discord servers](https://osu.ppy.sh/wiki/en/Community/Discord_servers#official-osu!-server) - List of various discord servers made by the osu! community
-- [ppy blog](https://blog.ppy.sh/) - Peppy's osu! development blog (not very active, but great a snapshot of osu! history)
+
+- [@osugame YouTube](https://www.youtube.com/@osugame) - The official osu!
+  YouTube channel for game updates and staff interviews
+- [@osugame Twitter](https://x.com/osugame) - The official osu! Twitter account
+  highlighting featured artists and official tournaments
+- [osu!wiki](https://osu.ppy.sh/wiki/en/Main_page) - Tons of different articles
+  about osu!
+- [osu! tournaments](https://osu.ppy.sh/community/tournaments) - The listing of
+  ongoing and past tournaments ran by the official game staff
+- [osu! Discord servers](https://osu.ppy.sh/wiki/en/Community/Discord_servers#official-osu!-server) -
+  List of various discord servers made by the osu! community
+- [ppy blog](https://blog.ppy.sh/) - Peppy's osu! development blog (not very
+  active, but great a snapshot of osu! history)
+
 ---
 ### Tablets
 - [OpenTabletDriver](https://opentabletdriver.net/) - Open-source tablet driver
@@ -20,11 +28,17 @@ This list is also available online at: https://resources.osucord.moe/
   - [Kuuube's Wacom Tablet Pen Compatibility Mastersheet](https://docs.google.com/spreadsheets/d/1UAFPjGj0ThthPBvOSVVwOm08HW3qWtVoP1iFBwLMyPI/edit)
   - [Kuuube's Wacom Pen Nib Guide](https://kuuube.s-ul.eu/mSDcCpuh)
 ---
+
 ### Replay and Score Analysis
+
 - [Danser-Go](https://github.com/Wieku/danser-go) - Render your replays locally
-- [o!rdr](https://ordr.issou.best/) - Render your replays online (powered by Danser-Go!)
-- [Rewind](https://github.com/abstrakt8/rewind) - Analyze replays in meticulous detail
-- [osu-aim-analyzer](https://github.com/rgbeing/osu-aim-analyzer) - A replay analysis tool to help analyze aim mistakes
+- [o!rdr](https://ordr.issou.best/) - Render your replays online (powered by
+  Danser-Go!)
+- [Rewind](https://github.com/abstrakt8/rewind) - Analyze replays in meticulous
+  detail
+- [osu-aim-analyzer](https://github.com/rgbeing/osu-aim-analyzer) - A replay
+  analysis tool to help analyze aim mistakes
+
 ---
 ### Stats Trackers
 - [osu!track](https://ameobea.me/osutrack/) - Track your pp gains and top 100 scores over time
@@ -32,13 +46,20 @@ This list is also available online at: https://resources.osucord.moe/
 - [osu!Stats](https://osustats.ppy.sh/) - Find scores that fit certain parameters
 - [osu!daily](https://osudaily.net/) - Track your profile, score, pp, and more
 ---
+
 ### Alternative Leaderboards
+
 - [Osekai](https://inex.osekai.net/) - Medal solutions and alternative rankings
-- [osu! scores inspector](https://score.kirino.sh/) - More alternative rankings, as well as clan leaderboards
-- [PP Rankings](https://pp.huismetbenen.nl/rankings/players/master) - Information and calculations for proposed and past pp reworks
-- [osu! World](https://osuworld.octo.moe/) - Provides provincial, state, and/or regional leaderboards
+- [osu! scores inspector](https://score.kirino.sh/) - More alternative rankings,
+  as well as clan leaderboards
+- [PP Rankings](https://pp.huismetbenen.nl/rankings/players/master) -
+  Information and calculations for proposed and past pp reworks
+- [osu! World](https://osuworld.octo.moe/) - Provides provincial, state, and/or
+  regional leaderboards
 - [osu!Skills](https://osuskills.com/) - Ranking based on individual skills
-- [osu!snipe](https://snipe.huismetbenen.nl/rankings/all) - Website for tracking various leaderboards, such as country #1 rankings
+- [osu!snipe](https://snipe.huismetbenen.nl/rankings/all) - Website for tracking
+  various leaderboards, such as country #1 rankings
+
 ---
 ### Alternative Clients
 - [osu!lazer](https://github.com/ppy/osu) - Official rewrite of the game with a modern design, a bunch of new mods and features
@@ -46,10 +67,16 @@ This list is also available online at: https://resources.osucord.moe/
 - [Web osu!mania](https://web-osu-mania.pages.dev/) - Play osu!mania in the browser
 - [osu!droid](https://osudroid.moe/) - osu! clone for Android devices
 ---
+
 ### Training Tools
-- [osu!Trainer](https://github.com/FunOrange/osu-trainer) - A program that allows you to modify the difficulty of a beatmap very quickly and easily
-- [cosu!Trainer](https://github.com/hwsmm/cosutrainer) - osu!Trainer alternative for Linux, written in C
-- [Shikke's Anti-Mindblock](https://shikkesora.com/downloads) - A tool to quickly flip your monitor upside-down to help with mind-block
+
+- [osu!Trainer](https://github.com/FunOrange/osu-trainer) - A program that
+  allows you to modify the difficulty of a beatmap very quickly and easily
+- [cosu!Trainer](https://github.com/hwsmm/cosutrainer) - osu!Trainer alternative
+  for Linux, written in C
+- [Shikke's Anti-Mindblock](https://shikkesora.com/downloads) - A tool to
+  quickly flip your monitor upside-down to help with mind-block
+
 ---
 ### Guides
 - [khz's streaming guide](https://docs.google.com/document/d/1xbNwH_vN4O3azBYwua-Z_3GOAI2d-kV_EeE96aiRLBU/edit) - A guide on how to get better at streaming
@@ -60,10 +87,17 @@ This list is also available online at: https://resources.osucord.moe/
 - [MarshNello's Installing osu! on Linux](https://osu.ppy.sh/community/forums/topics/1248084) - A guide for how to set up osu! to run smoothly on Linux
   - [Even lower latency](https://github.com/NelloKudo/osu-winello/wiki/Even-lower-latency:-PipeWire-settings) - Some additional settings you should consider for even lower audio latency on Linux
 ---
+
 ### Beatmap Management Tools
-- [Batch Beatmap Downloader](https://github.com/nzbasic/batch-beatmap-downloader) - Tool to mass download beatmaps, you can also apply filters and create collections for the downloaded beatmaps
-- [Collection Manager](https://github.com/Piotrekol/CollectionManager) - Import and export collections made by yourself as well as other players
-- [osu! cleaner](https://github.com/TCNOco/TcNo-osu-Cleaner) - Tool to save space by deleting unnecessary elements from beatmaps
+
+- [Batch Beatmap Downloader](https://github.com/nzbasic/batch-beatmap-downloader) -
+  Tool to mass download beatmaps, you can also apply filters and create
+  collections for the downloaded beatmaps
+- [Collection Manager](https://github.com/Piotrekol/CollectionManager) - Import
+  and export collections made by yourself as well as other players
+- [osu! cleaner](https://github.com/TCNOco/TcNo-osu-Cleaner) - Tool to save
+  space by deleting unnecessary elements from beatmaps
+
 ---
 ### Beatmap Search Tools
 - [Advanced in-game/web search](https://osu.ppy.sh/wiki/en/Beatmap_search) - Wiki article on how to use the advanced search features in-game and on the website search bar
@@ -73,11 +107,17 @@ This list is also available online at: https://resources.osucord.moe/
 - [osu!pps](https://osu-pps.com/#/osu/maps) - Website for finding common farm maps within your skill range
 - [osu! Beatmap Atlas](https://osu-atlas.ameo.dev/) - A map that groups similar beatmaps together in space
 ---
+
 ### Skins
+
 - [osuck](https://skins.osuck.net/) - Website to get skins for all game modes
-- [Skinship's skin compendium](https://compendium.skinship.xyz/) - Easy to search archive of all osu! skins posted in the Completed Skins forum
-- [Circle People](https://circle-people.com/skins/) - List of skins used by various well-known players
-- [OsuSkinMixer](https://github.com/rednir/OsuSkinMixer) - A tool to easily mix various elements of skins
+- [Skinship's skin compendium](https://compendium.skinship.xyz/) - Easy to
+  search archive of all osu! skins posted in the Completed Skins forum
+- [Circle People](https://circle-people.com/skins/) - List of skins used by
+  various well-known players
+- [OsuSkinMixer](https://github.com/rednir/OsuSkinMixer) - A tool to easily mix
+  various elements of skins
+
 ---
 ### Mapping Resources
 - [Mappers' Guild](https://mappersguild.com/) - A hub for beatmaps associated with osu!'s Featured Artists
@@ -90,13 +130,23 @@ This list is also available online at: https://resources.osucord.moe/
 - [Lasse's Hitsounding Guide](https://docs.google.com/document/d/1tS5udToW_SEiCKNFSg7DUuZmsdroUOO8cRYEcwZV9P8/edit) - A guide for those learning hitsounding
 - [Sliderbase](https://photos.google.com/share/AF1QipM-5gNgHPHcVQomyu8xFlHw25h4KoQptjBkGg6WV8wtJtdvhXP2eTYcSlJbNLXziQ?pli=1&key=N1FWWk81ZFpBdGVwajZIS3A0cHB0ZUxDZWpFT2Vn) - A collection of sliders for beatmaps
 ---
+
 ### Mapping Tools
-- [OliBomby's Mapping Tools](https://mappingtools.github.io/) - Advanced tools to facilitate mapping
-- [Naxesss' Mapset Verifier](https://github.com/Naxesss/MapsetVerifier) - Tools to make sure your map is ready for ranking ([taiko](https://github.com/Hiviexd/MVTaikoChecks)/[mania](https://github.com/MChecaH/ManiaCheck) plugins)
-- [osu! Web Beatmap Viewer](https://preview.tryz.id.vn/) - View a beatmap in an editor-like interface in the browser
-- [Agka's SV Tools](https://zardoru.github.io/sv-tools/) - Tools to help create and edit Scroll Velocities for the osu!mania mode
-- [ArrowVortex](https://arrowvortex.ddrnl.com/) - Alternative map editor for various VSRGs
+
+- [OliBomby's Mapping Tools](https://mappingtools.github.io/) - Advanced tools
+  to facilitate mapping
+- [Naxesss' Mapset Verifier](https://github.com/Naxesss/MapsetVerifier) - Tools
+  to make sure your map is ready for ranking
+  ([taiko](https://github.com/Hiviexd/MVTaikoChecks)/[mania](https://github.com/MChecaH/ManiaCheck)
+  plugins)
+- [osu! Web Beatmap Viewer](https://preview.tryz.id.vn/) - View a beatmap in an
+  editor-like interface in the browser
+- [Agka's SV Tools](https://zardoru.github.io/sv-tools/) - Tools to help create
+  and edit Scroll Velocities for the osu!mania mode
+- [ArrowVortex](https://arrowvortex.ddrnl.com/) - Alternative map editor for
+  various VSRGs
 - [osucad](https://osucad.com/) - A collaborative beatmap editor
+
 ---
 ### Browser Extensions
 - [osuplus](https://osu.ppy.sh/community/forums/topics/408541?n=1) - Extension that adds extra features to the osu! website
@@ -106,11 +156,19 @@ This list is also available online at: https://resources.osucord.moe/
 - [pp calculator](https://osu.ppy.sh/community/forums/topics/1504072?n=1) - Calculate how much PP a map is worth for a particular score
 - [osu-color-changer](https://userstyles.world/style/1767/osu-color-changer) - A userstyle allowing various colour and stylistic changes for the osu! website, featuring many customization options
 ---
+
 ### Streaming
-- [StreamCompanion](https://github.com/Piotrekol/StreamCompanion) - Provides various overlays such as pp counters, map information, and more. Can be used for streaming or in-game
-- [Ronnia](https://ronnia.me/) - Twitch/osu! bot that sends beatmap requests from Twitch chat to the streamer's in-game messages
-- [JKPS](https://github.com/Tonetfal/JKPS) - Keyboard overlay featuring key press visualisation and a keys per second meter
-- [osu! Tourney Match Display](https://otmd.app/) - Shows real-time stats of an ongoing osu! multiplayer match while streaming
+
+- [StreamCompanion](https://github.com/Piotrekol/StreamCompanion) - Provides
+  various overlays such as pp counters, map information, and more. Can be used
+  for streaming or in-game
+- [Ronnia](https://ronnia.me/) - Twitch/osu! bot that sends beatmap requests
+  from Twitch chat to the streamer's in-game messages
+- [JKPS](https://github.com/Tonetfal/JKPS) - Keyboard overlay featuring key
+  press visualisation and a keys per second meter
+- [osu! Tourney Match Display](https://otmd.app/) - Shows real-time stats of an
+  ongoing osu! multiplayer match while streaming
+
 ---
 ### Tournaments
 - [osu! on Liquipedia](https://liquipedia.net/osu/Main_Page) - Wiki for past and future tournaments documenting participants, map pools, matchups, prizes and more
@@ -121,12 +179,24 @@ This list is also available online at: https://resources.osucord.moe/
 - [Mario564's Team Tournament Template](https://l-mario564.github.io/Team-Tournament-Spreadsheet-Documentation/index.html) - A Google Sheets template to manage a team's availability, tryout map pools, compare your teams's and opponent scores
 - [Squink's Tournament History Template](https://docs.google.com/spreadsheets/d/18UWiooGGDMMkltJGm_Td1b72MVRnQQ5ceS21w2zm16U/edit?gid=230730286#gid=230730286) - A Google Sheets template for tracking personal tournament history
 ---
+
 ### Discord Bots
-- [BathBot](https://github.com/MaxOhn/Bathbot) - A feature-rich bot with functionality all around osu! - check your recent plays, compare top scores among players, play the background guessing game and more
-- [owo](http://owo-bot.xyz/) - A general-purpose bot to show off your profile/recent plays, get map recommendations, compare yourself to others and more
-- [Yuna](https://discord.com/oauth2/authorize?client_id=832597585923014676&scope=bot&permissions=60480) - The official [o!rdr](https://ordr.issou.best/) bot, useful to render replays through discord chat
-- [AxerBot](https://github.com/Hiviexd/AxerBot) - A general-purpose and powerful bot with osu! features related to mapping & modding
-- [osu! Miss Analyzer](https://github.com/ThereGoesMySanity/osuMissAnalyzer) - A tool to analyze misses in an osu! replay (has a discord bot and program to run locally)
+
+- [BathBot](https://github.com/MaxOhn/Bathbot) - A feature-rich bot with
+  functionality all around osu! - check your recent plays, compare top scores
+  among players, play the background guessing game and more
+- [owo](http://owo-bot.xyz/) - A general-purpose bot to show off your
+  profile/recent plays, get map recommendations, compare yourself to others and
+  more
+- [Yuna](https://discord.com/oauth2/authorize?client_id=832597585923014676&scope=bot&permissions=60480) -
+  The official [o!rdr](https://ordr.issou.best/) bot, useful to render replays
+  through discord chat
+- [AxerBot](https://github.com/Hiviexd/AxerBot) - A general-purpose and powerful
+  bot with osu! features related to mapping & modding
+- [osu! Miss Analyzer](https://github.com/ThereGoesMySanity/osuMissAnalyzer) - A
+  tool to analyze misses in an osu! replay (has a discord bot and program to run
+  locally)
+
 ---
 ### In-game Bots
 These are some of the bots that can be used in the in-game chat. Find the account by username and message them with the commands to get a response.
@@ -134,8 +204,17 @@ These are some of the bots that can be used in the in-game chat. Find the accoun
 - [Ameo](https://osu.ppy.sh/users/4093752) ([commands](https://ameobea.me/osutrack/updater/index.php)) - Interfaces with [osu!track](https://ameobea.me/osutrack/) to provide personal stat changes in-game
 - [Sombrax79](https://osu.ppy.sh/users/6484647) ([commands](https://ost.sombrax79.org/commands)) - Recommendations for stamina intensive beatmaps
 ---
+
 ### Misc
-- [osu!mania Pattern Repository](https://imgur.com/a/replacement-glossary-osu-mania-pattern-repository-qEwP37W) - A glossary of common osu!mania patterns and terms
-- [Alexaaro's Imagemap Generator](https://alexaario.github.io/osu-BBCodeImagemapGenerator/) - A tool to create BBCode for imagemaps
-- [Mutualify](https://mutualify.stanr.info/) - Find people that are following you, but that you have not mutualed
-- [osu! beatmap heatmap](https://osu-heatmap.ekga.me/) - View the playfield usage of a beatmap, sometimes revealing a hidden beauty some mappers hide in their maps
+
+- [osu!mania Pattern Repository](https://imgur.com/a/replacement-glossary-osu-mania-pattern-repository-qEwP37W) -
+  A glossary of common osu!mania patterns and terms
+- [Alexaaro's Imagemap Generator](https://alexaario.github.io/osu-BBCodeImagemapGenerator/) -
+  A tool to create BBCode for imagemaps
+- [Mutualify](https://mutualify.stanr.info/) - Find people that are following
+  you, but that you have not mutualed
+- [osu! beatmap heatmap](https://osu-heatmap.ekga.me/) - View the playfield
+  usage of a beatmap, sometimes revealing a hidden beauty some mappers hide in
+  their maps
+- [osu! Tablet Area Calculator](https://osu-tableno.deno.dev/) - Calculate a
+  tablet area (in millimetres) with a close approximation of 4:3 aspect ratio


### PR DESCRIPTION
Excuse the formatting done by i-have-no-idea (VSCode or Deno plugin?).

This PR corresponds to issue #58 and to the following places:
https://osu-tableno.deno.dev/
https://github.com/kawarbon/osu-tableno

As discussed, one of the needs was a visualiser:
![image](https://github.com/user-attachments/assets/7947480a-8e52-4788-a13c-7d5448bdddb5)

And as discussed after, an explanation or informatics related to the application have been provided access to via a `(i)` icon:
![image](https://github.com/user-attachments/assets/bccabd4b-218b-4f01-86bc-a17a690ab518)

As these matters are subject to change, it would be nice to discuss and finalise this further before merging.